### PR TITLE
Init for cosmos chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+.vscode
+.makeFlags

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: go
+
+services:
+  docker
+
+go:
+  - "1.13"
+
+script:
+  - if [ -n "$(gofmt -l .)" ]; then echo "Go code is not formatted:"; gofmt -d .; exit 1; fi
+  - make test
+
+deploy:
+  - provider: script
+    script:
+      - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD && make push
+    on:
+      branch: master
+
+cache:
+  directories:
+    - $GOPATH/pkg

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+TRAVIS_BRANCH ?= $(shell git branch| grep \* | cut -d' ' -f2)
+BRANCH=$(TRAVIS_BRANCH)
+
+flags=.makeFlags
+VPATH=$(flags)
+$(shell mkdir -p $(flags))
+
+dockerRepo=hashcloak
+katzenServerRepo=https://github.com/katzenpost/server
+katzenServerTag=$(shell git ls-remote --heads $(katzenServerRepo) | grep master | cut -c1-7)
+katzenServer=$(dockerRepo)/katzenpost-server:$(katzenServerTag)
+mesonServer=$(dockerRepo)/meson
+
+messagePush=echo "LOG: Image already exists in docker.io/$(dockerRepo). Not pushing: "
+messagePull=echo "LOG: Success in pulling image: "
+imageNotFound=echo "LOG: Image not found... building: "
+
+clean:
+	rm -rf /tmp/server
+	rm -rf $(flags)
+
+pull-katzen-server:
+	docker pull $(katzenServer) && $(messagePull)$(katzenServer) \
+		|| ($(imageNotFound)$(katzenServer) && $(MAKE) build-katzen-server)
+	@touch $(flags)/$@
+
+push: push-katzen-server push-meson
+
+push-katzen-server:
+	docker push $(katzenServer) && $(messagePush)$(katzenServer) \
+		|| ($(imageNotFound)$(katzenServer) && \
+				$(MAKE) build-katzen-server; docker push $(katzenServer))
+
+push-meson: build-meson
+	docker push '$(mesonServer):$(BRANCH)'
+
+build: build-katzen-server build-meson
+
+build-katzen-server:
+	git clone $(katzenServerRepo) /tmp/server || git --git-dir=/tmp/server/.git --work-tree=/tmp/server pull origin master
+	docker build -f /tmp/server/Dockerfile -t $(katzenServer) /tmp/server
+	@touch $(flags)/$@
+
+build-meson: pull-katzen-server
+	sed 's|%%KATZEN_SERVER%%|$(katzenServer)|g' ./Dockerfile > /tmp/meson.Dockerfile
+	docker build -f /tmp/meson.Dockerfile -t $(mesonServer):$(BRANCH) .
+	@touch $(flags)/$@
+
+test:
+	go test ./pkg/*

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ dockerRepo=hashcloak
 katzenServerRepo=https://github.com/katzenpost/server
 katzenServerTag=$(shell git ls-remote --heads $(katzenServerRepo) | grep master | cut -c1-7)
 katzenServer=$(dockerRepo)/katzenpost-server:$(katzenServerTag)
-mesonServer=$(dockerRepo)/meson
+mesonServer=$(dockerRepo)/Meson
 
 messagePush=echo "LOG: Image already exists in docker.io/$(dockerRepo). Not pushing: "
 messagePull=echo "LOG: Success in pulling image: "

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -1,7 +1,13 @@
 package chain
 
+// PostRequest is the common struct containing the body and url
+type PostRequest struct {
+	Body []byte
+	URL  string
+}
+
 // IChain is an abstraction for a cryptocurrency
 // It only enables creating raw transactions requests
 type IChain interface {
-	NewRequest(txHex string) ([]byte, error)
+	NewRequest(rpcURL string, txHex string) (PostRequest, error)
 }

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -9,5 +9,7 @@ type PostRequest struct {
 // IChain is an abstraction for a cryptocurrency
 // It only enables creating raw transactions requests
 type IChain interface {
+	// NewRequest takes an RPC URL and a hexadecimal transaction.
+	// Returns PostRequest with the with values depending on the chain type
 	NewRequest(rpcURL string, txHex string) (PostRequest, error)
 }

--- a/pkg/chain/chain_test.go
+++ b/pkg/chain/chain_test.go
@@ -1,0 +1,54 @@
+package chain
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+const (
+	broadcastTxAsync = "/broadcast_tx_async?tx="
+)
+
+func TestChainFactoryError(t *testing.T) {
+	_, err := GetChain("SOMETHING")
+	if err == nil {
+		t.Fatalf("Should return an error")
+	}
+}
+
+func TestChainFactoryErrorEmpty(t *testing.T) {
+	_, err := GetChain("")
+	if err == nil {
+		t.Fatalf("Should return an error")
+	}
+}
+
+func TestEthereumChainTxnInBody(t *testing.T) {
+	chainInterface, _ := GetChain("ETH")
+	txn := `"TXN"`
+	postRequest, _ := chainInterface.NewRequest("", txn)
+	var expectedValue ethRequest
+	json.Unmarshal(postRequest.Body, &expectedValue)
+	if len(expectedValue.Params) != 1 {
+		t.Fatalf("Length expected to be %d, got %d", 1, len(expectedValue.Params))
+	}
+	if expectedValue.Params[0] != txn {
+		t.Fatalf("Expected %s, got %s", txn, expectedValue.Params[0])
+	}
+}
+func TestCosmosChainBody(t *testing.T) {
+	chainInterface, _ := GetChain("TBNB")
+	postRequest, _ := chainInterface.NewRequest("", "")
+	if bytes.Compare(postRequest.Body, []byte{}) != 0 {
+		t.Fatalf("Body should be empty for Cosmos request")
+	}
+}
+func TestCosmosChainURL(t *testing.T) {
+	chainInterface, _ := GetChain("TBNB")
+	postRequest, _ := chainInterface.NewRequest("", "")
+	t.Log("HI")
+	if postRequest.URL != broadcastTxAsync {
+		t.Fatalf("URL should have value %s, got %s", broadcastTxAsync, postRequest.URL)
+	}
+}

--- a/pkg/chain/chain_test.go
+++ b/pkg/chain/chain_test.go
@@ -37,29 +37,31 @@ func TestEthereumChainTxnInBody(t *testing.T) {
 		t.Fatalf("Expected %s, got %s", txn, expectedValue.Params[0])
 	}
 }
-func TestCosmosChainBody(t *testing.T) {
-	chainInterface, _ := GetChain("TBNB")
-	postRequest, _ := chainInterface.NewRequest("", "")
-	if bytes.Compare(postRequest.Body, []byte{}) != 0 {
-		t.Fatalf("Body should be empty for Cosmos request")
-	}
-}
+
 func TestCosmosChainURLEmpty(t *testing.T) {
 	chainInterface, _ := GetChain("TBNB")
-	postRequest, _ := chainInterface.NewRequest("", "")
-	if postRequest.URL != broadcastTxAsync {
-		t.Fatalf("URL should have value %s, got %s", broadcastTxAsync, postRequest.URL)
+	_, err := chainInterface.NewRequest("", "")
+	if err == nil {
+		t.Fatalf("Should return an error when passed empty URL")
+	}
+}
+func TestCosmosChainBody(t *testing.T) {
+	chainInterface, _ := GetChain("TBNB")
+	postRequest, _ := chainInterface.NewRequest("URL", "")
+	if bytes.Compare(postRequest.Body, []byte{}) != 0 {
+		t.Fatalf("Body should be empty for cosmos request")
 	}
 }
 func TestCosmosChainURLAppend(t *testing.T) {
 	chainInterface, _ := GetChain("TBNB")
-	expectedTxn := "EXPECTED_TXN"
-	postRequest, _ := chainInterface.NewRequest("", expectedTxn)
-	if postRequest.URL != broadcastTxAsync+expectedTxn {
+	inputTxn := "EXPECTED_TXN"
+	inputURL := "URL"
+	expectedResult := inputURL + broadcastTxAsync + inputTxn
+	postRequest, _ := chainInterface.NewRequest(inputURL, inputTxn)
+	if postRequest.URL != expectedResult {
 		t.Fatalf("URL should have value %s, got %s", broadcastTxAsync, postRequest.URL)
 	}
 }
-
 func TestCosmosChainURL(t *testing.T) {
 	chainInterface, _ := GetChain("TBNB")
 	expectedURL := "EXPECTED_URL"

--- a/pkg/chain/chain_test.go
+++ b/pkg/chain/chain_test.go
@@ -24,10 +24,31 @@ func TestChainFactoryErrorEmpty(t *testing.T) {
 	}
 }
 
+func TestEthereumChainURLEmptyValue(t *testing.T) {
+	chainInterface, _ := GetChain("ETH")
+	_, err := chainInterface.NewRequest("", "")
+	if err == nil {
+		t.Fatalf("Should return an error")
+	}
+	expectedErrorValue := "Non existent RPC URL for Ethereum chain"
+	if err.Error() != expectedErrorValue {
+		t.Fatalf("Not the right error value.\nExpected: %s\nGot: %s", expectedErrorValue, err.Error())
+	}
+}
+
+func TestEthereumChainURLValue(t *testing.T) {
+	chainInterface, _ := GetChain("ETH")
+	expectedURL := "EXPECTED_URL"
+	postRequest, _ := chainInterface.NewRequest(expectedURL, "")
+	if postRequest.URL != expectedURL {
+		t.Fatalf("Expected %s, got %s", expectedURL, postRequest.URL)
+	}
+}
+
 func TestEthereumChainTxnInBody(t *testing.T) {
 	chainInterface, _ := GetChain("ETH")
 	txn := `"TXN"`
-	postRequest, _ := chainInterface.NewRequest("", txn)
+	postRequest, _ := chainInterface.NewRequest("URL", txn)
 	var expectedValue ethRequest
 	json.Unmarshal(postRequest.Body, &expectedValue)
 	if len(expectedValue.Params) != 1 {

--- a/pkg/chain/chain_test.go
+++ b/pkg/chain/chain_test.go
@@ -44,11 +44,27 @@ func TestCosmosChainBody(t *testing.T) {
 		t.Fatalf("Body should be empty for Cosmos request")
 	}
 }
-func TestCosmosChainURL(t *testing.T) {
+func TestCosmosChainURLEmpty(t *testing.T) {
 	chainInterface, _ := GetChain("TBNB")
 	postRequest, _ := chainInterface.NewRequest("", "")
-	t.Log("HI")
 	if postRequest.URL != broadcastTxAsync {
+		t.Fatalf("URL should have value %s, got %s", broadcastTxAsync, postRequest.URL)
+	}
+}
+func TestCosmosChainURLAppend(t *testing.T) {
+	chainInterface, _ := GetChain("TBNB")
+	expectedTxn := "EXPECTED_TXN"
+	postRequest, _ := chainInterface.NewRequest("", expectedTxn)
+	if postRequest.URL != broadcastTxAsync+expectedTxn {
+		t.Fatalf("URL should have value %s, got %s", broadcastTxAsync, postRequest.URL)
+	}
+}
+
+func TestCosmosChainURL(t *testing.T) {
+	chainInterface, _ := GetChain("TBNB")
+	expectedURL := "EXPECTED_URL"
+	postRequest, _ := chainInterface.NewRequest(expectedURL, "")
+	if postRequest.URL != expectedURL+broadcastTxAsync {
 		t.Fatalf("URL should have value %s, got %s", broadcastTxAsync, postRequest.URL)
 	}
 }

--- a/pkg/chain/cosmos_chain.go
+++ b/pkg/chain/cosmos_chain.go
@@ -11,7 +11,7 @@ type CosmosChain struct {
 }
 
 // NewRequest : Takes signed transaction data as a parameter
-// Returns a marshalled request
+// Returns a URL endpoint
 func (ec *CosmosChain) NewRequest(rpcURL string, txHex string) (PostRequest, error) {
 	URL := fmt.Sprintf("%s/broadcast_tx_async?tx=%s", rpcURL, txHex)
 	return PostRequest{URL: URL}, nil

--- a/pkg/chain/cosmos_chain.go
+++ b/pkg/chain/cosmos_chain.go
@@ -10,8 +10,8 @@ type CosmosChain struct {
 	chainID int
 }
 
-// NewRequest : Takes signed transaction data as a parameter
-// Returns a URL endpoint
+// NewRequest takes an RPC URL and a hexadecimal transaction and
+// returns a concatenated URL
 func (ec *CosmosChain) NewRequest(rpcURL string, txHex string) (PostRequest, error) {
 	if len(rpcURL) == 0 {
 		return PostRequest{}, fmt.Errorf("No URL value for cosmos api")

--- a/pkg/chain/cosmos_chain.go
+++ b/pkg/chain/cosmos_chain.go
@@ -13,6 +13,9 @@ type CosmosChain struct {
 // NewRequest : Takes signed transaction data as a parameter
 // Returns a URL endpoint
 func (ec *CosmosChain) NewRequest(rpcURL string, txHex string) (PostRequest, error) {
+	if len(rpcURL) == 0 {
+		return PostRequest{}, fmt.Errorf("No URL value for cosmos api")
+	}
 	URL := fmt.Sprintf("%s/broadcast_tx_async?tx=%s", rpcURL, txHex)
 	return PostRequest{URL: URL}, nil
 }

--- a/pkg/chain/cosmos_chain.go
+++ b/pkg/chain/cosmos_chain.go
@@ -1,0 +1,18 @@
+package chain
+
+import (
+	"fmt"
+)
+
+// CosmosChain is a struct for identifier blockchains and their forks
+type CosmosChain struct {
+	ticker  string
+	chainID int
+}
+
+// NewRequest : Takes signed transaction data as a parameter
+// Returns a marshalled request
+func (ec *CosmosChain) NewRequest(rpcURL string, txHex string) (PostRequest, error) {
+	URL := fmt.Sprintf("%s/broadcast_tx_async?tx=%s", rpcURL, txHex)
+	return PostRequest{URL: URL}, nil
+}

--- a/pkg/chain/cosmos_chain.go
+++ b/pkg/chain/cosmos_chain.go
@@ -10,8 +10,8 @@ type CosmosChain struct {
 	chainID int
 }
 
-// NewRequest takes an RPC URL and a hexadecimal transaction and
-// returns a concatenated URL
+// NewRequest takes an RPC URL and a hexadecimal transaction.
+// Returns PostRequest for cosmos nodes
 func (ec *CosmosChain) NewRequest(rpcURL string, txHex string) (PostRequest, error) {
 	if len(rpcURL) == 0 {
 		return PostRequest{}, fmt.Errorf("No URL value for cosmos api")

--- a/pkg/chain/ethereum_chain.go
+++ b/pkg/chain/ethereum_chain.go
@@ -27,7 +27,7 @@ type ETHChain struct {
 }
 
 // NewRequest takes an RPC URL and a hexadecimal transaction.
-// Returns a marshalled request with the same RPC URL
+// Returns PostRequest for ethereum nodes
 func (ec *ETHChain) NewRequest(rpcURL string, txHex string) (PostRequest, error) {
 	if len(rpcURL) == 0 {
 		return PostRequest{}, fmt.Errorf("Non existent RPC URL for Ethereum chain")

--- a/pkg/chain/ethereum_chain.go
+++ b/pkg/chain/ethereum_chain.go
@@ -35,5 +35,5 @@ func (ec *ETHChain) NewRequest(rpcURL string, txHex string) (PostRequest, error)
 		Params:  []string{txHex},
 	}
 	marshalledRequest, err := json.Marshal(er)
-	return PostRequest{URL: "", Body: marshalledRequest}, err
+	return PostRequest{Body: marshalledRequest}, err
 }

--- a/pkg/chain/ethereum_chain.go
+++ b/pkg/chain/ethereum_chain.go
@@ -27,14 +27,13 @@ type ETHChain struct {
 
 // NewRequest : Takes signed transaction data as a parameter
 // Returns a marshalled request
-func (ec *ETHChain) NewRequest(txHex string) ([]byte, error){
-	er := ethRequest {
-		ID: ec.chainID,
+func (ec *ETHChain) NewRequest(rpcURL string, txHex string) (PostRequest, error) {
+	er := ethRequest{
+		ID:      ec.chainID,
 		JSONRPC: "2.0",
-		METHOD: "eth_sendRawTransaction",
-		Params: []string{txHex},
+		METHOD:  "eth_sendRawTransaction",
+		Params:  []string{txHex},
 	}
-
 	marshalledRequest, err := json.Marshal(er)
-	return marshalledRequest, err
+	return PostRequest{URL: "", Body: marshalledRequest}, err
 }

--- a/pkg/chain/ethereum_chain.go
+++ b/pkg/chain/ethereum_chain.go
@@ -26,8 +26,8 @@ type ETHChain struct {
 	ticker  string
 }
 
-// NewRequest : Takes signed transaction data as a parameter
-// Returns a marshalled request
+// NewRequest takes an RPC URL and a hexadecimal transaction.
+// Returns a marshalled request with the same RPC URL
 func (ec *ETHChain) NewRequest(rpcURL string, txHex string) (PostRequest, error) {
 	if len(rpcURL) == 0 {
 		return PostRequest{}, fmt.Errorf("Non existent RPC URL for Ethereum chain")

--- a/pkg/chain/ethereum_chain.go
+++ b/pkg/chain/ethereum_chain.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // An ethereum request abstraction.
@@ -28,6 +29,9 @@ type ETHChain struct {
 // NewRequest : Takes signed transaction data as a parameter
 // Returns a marshalled request
 func (ec *ETHChain) NewRequest(rpcURL string, txHex string) (PostRequest, error) {
+	if len(rpcURL) == 0 {
+		return PostRequest{}, fmt.Errorf("Non existent RPC URL for Ethereum chain")
+	}
 	er := ethRequest{
 		ID:      ec.chainID,
 		JSONRPC: "2.0",
@@ -35,5 +39,5 @@ func (ec *ETHChain) NewRequest(rpcURL string, txHex string) (PostRequest, error)
 		Params:  []string{txHex},
 	}
 	marshalledRequest, err := json.Marshal(er)
-	return PostRequest{Body: marshalledRequest}, err
+	return PostRequest{URL: rpcURL, Body: marshalledRequest}, err
 }

--- a/pkg/chain/factory.go
+++ b/pkg/chain/factory.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 )
 
-
 // GetChain takes a ticker symbol for a supported chain and returns an interface
 // for that chain
 func GetChain(ticker string) (IChain, error) {
@@ -20,8 +19,11 @@ func GetChain(ticker string) (IChain, error) {
 		return &ETHChain{ticker: "RIN", chainID: 4}, nil
 	case "KOT":
 		return &ETHChain{ticker: "KOT", chainID: 6}, nil
+	case "TBNB":
+		return &CosmosChain{ticker: "TBNB", chainID: 0}, nil
+	case "BNB":
+		return &CosmosChain{ticker: "BNB", chainID: 1}, nil
 	default:
 		return nil, fmt.Errorf("Unsupported chain")
 	}
 }
-

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -122,15 +122,14 @@ func (k *Currency) sendTransaction(ticker string, txHex string) error {
 		return err
 	}
 	// Create a new appropriately marshalled request
-	marshalledRequest, err := c.NewRequest(txHex)
+	postRequest, err := c.NewRequest(k.rpcURL, txHex)
 	if err != nil {
 		return err
 	}
 
-	bodyReader := bytes.NewReader(marshalledRequest)
-
 	// create an http request
-	httpReq, err := http.NewRequest("POST", k.rpcURL, bodyReader)
+	httpReq, err := http.NewRequest("POST", postRequest.URL, bytes.NewReader(postRequest.Body))
+
 	if err != nil {
 		return err
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -131,7 +131,6 @@ func (k *Currency) sendTransaction(ticker string, txHex string) error {
 
 	// create an http request
 	httpReq, err := http.NewRequest("POST", k.rpcURL, bodyReader)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -127,8 +127,10 @@ func (k *Currency) sendTransaction(ticker string, txHex string) error {
 		return err
 	}
 
+	bodyReader := bytes.NewReader(postRequest.Body)
+
 	// create an http request
-	httpReq, err := http.NewRequest("POST", postRequest.URL, bytes.NewReader(postRequest.Body))
+	httpReq, err := http.NewRequest("POST", k.rpcURL, bodyReader)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
The biggest change is the addition of the `PostRequest` type to the `chain` package. The reason I decided on this change are:
- Cosmos needs a URL as its api endpoint path. So I needed a way to pass it to chain to and back out to the actual `POST` request.

This added the following changes:
- `PostRequest` returns a URL and  Body. In the case of the ethereum chain, the URL is empty. In the case of the cosmos chain, the Body is empty.
- new `rpcURL` parameter for `NewRequest`

Some additional changes are:
- Binance chain in the factory.